### PR TITLE
Some fixes of file path

### DIFF
--- a/Configuration/test/TMVATesting/MassSpectrum.h
+++ b/Configuration/test/TMVATesting/MassSpectrum.h
@@ -61,7 +61,7 @@ public :
    unordered_map<string,TMVA::Reader *> readerMap;
    TMVA::Reader* reader[3] = {};
    
-   TString trainingDir = "/eos/cms/store/cmst3/user/evourlio/L1uGMTAnalyzer_Trees/TMVATrainingFiles/"; // Change accordingly
+   TString trainingDir = "/home/cmsdas/public/store/MLShortExercise/TMVATrainingFiles/"; // Change accordingly
    TString era = "BCEF"; //Change accordingly
    float L1muon_ptCorr_, L1muon_pt_, L1muon_eta_,L1muon_phi_, L1muon_charge_, L1muon_index_;
 

--- a/Configuration/test/TMVATesting/Resolutions.h
+++ b/Configuration/test/TMVATesting/Resolutions.h
@@ -53,7 +53,7 @@ public :
    unordered_map<string,TMVA::Reader *> readerMap;
    TMVA::Reader* reader[3] = {};
    
-   TString trainingDir = "/eos/cms/store/cmst3/user/evourlio/L1uGMTAnalyzer_Trees/TMVATrainingFiles/"; //Change accordingly
+   TString trainingDir = "/home/cmsdas/public/store/MLShortExercise/TMVATrainingFiles/"; //Change accordingly
    TString era = "BCEF"; //Change accordingly
    float L1muon_ptCorr_, L1muon_pt_, L1muon_eta_,L1muon_phi_, L1muon_charge_, L1muon_index_;
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cd MLShEx_CorrL1Muons/Configuration/
 * Discussion on the TMVA.
 * Run  
    ```
-   cd ../test/TMVATraining  
+   cd ../TMVATraining  
    python TMVATraining.py
    ```
 * Understand [_TMVATraining.py_](../exercise_CMSDASServer/Configuration/test/TMVATraining/TMVATraining.py), [_TMVARegression.C_](../exercise_CMSDASServer/Configuration/test/TMVATraining/TMVARegression.C) and inspect the input files.


### PR DESCRIPTION
I've changed `trainingDir` to the path existing on PKU Cluster. The original path cannot be accessed and will raise an error, I guess this is not a standard part of the exercise?

As for the README fix, when we just run `cd ../test/skimming` we are at `skimming` folder, and `TMVATraining` folder is located at its parent directory.